### PR TITLE
Single line that increases performance a lot

### DIFF
--- a/src/dkbbasis.h
+++ b/src/dkbbasis.h
@@ -735,6 +735,7 @@ class dkbbasis: public basis<dkbbasis>, public splineHandler {
 				}
 			}
 			
+			prevTime = vExt->getTime();
 			
 			// if(vExt->getTime()!=prevTime || bdpl!=prevL || ul!=prevul) {
 				// prevL = bdpl;


### PR DESCRIPTION
Basically, in the implementation of the nondipole matrix-matrix product function in dkbbasis.h, I do a somewhat expensive sum over sparse matrices under the assumption that this will be reused a lot

I forgot the line that ensures it's reused until it has to be recalculated, as I noticed while profiling just now

This should make it run a lot faster.