### PR TITLE
replaced function "expm" in defs.h 

### DIFF
--- a/input_example.json
+++ b/input_example.json
@@ -1,8 +1,8 @@
 {
   "Nsplines": 150,
   "Ntime": 100,
-  "Nkappa": 4,
-  "Nmu": 1,
-  "Nl": 1,
+  "Nkappa": 20,
+  "Nmu": 10,
+  "Nl": 10,
   "rBox": 30.0
 }

--- a/src/nondipoleMPItest.cpp
+++ b/src/nondipoleMPItest.cpp
@@ -153,7 +153,8 @@ int main(int argc, char* argv[]) {
 	// vec angInit = vec::Constant(rthphb.angqN(),1.0);
 
 	rthphb.pruneUncoupled(angInit,true); //true means using nondipole couplings
-
+	
+	
 	//Dump enumeration of angular momentum states, this is needed in postprocessing of data
 	for(int i = 0; i < rthphb.angids.size(); i++) {
 		cout << "(" << i << ", " << rthphb.angids[i] << ", " << ik(rthphb.angids[i])<< ", " << imu(rthphb.angids[i]) << ")," << std::endl;

--- a/src/rthphbasis.h
+++ b/src/rthphbasis.h
@@ -22,6 +22,24 @@ template <typename T> int sgn(T val) {
     return (T(0) < val) - (val < T(0));
 }
 
+cvec expmvec(const csmat& mat, const cvec& vec, int n) {
+	int N = mat.rows();
+	
+	cvec out = vec;
+	cvec Mv = vec;
+	
+	
+	
+	for(int i = 1; i < n; i++) {
+		Mv = (mat * Mv) / i;
+		out += Mv;
+		
+		// cout << i << endl << out << endl << endl;
+	}
+	
+	return out;
+}
+
 template <typename rbtype, typename thphbtype>
 class rthphbasis;
 
@@ -3221,7 +3239,7 @@ class rthphbasis: public basis<rthphbasis<rbtype, thphbtype> > {
 		void pruneUncoupled(vec angStates,bool bdp = false) {
 			if(isCached(angCouplings(bdp))) {
 				
-				cmat angcp = -cdouble(0,1) * cmat(angCouplings(bdp));
+				csmat angcp = angCouplings(bdp);
 				
 				// cout << angcp << "\n";
 				
@@ -3230,11 +3248,14 @@ class rthphbasis: public basis<rthphbasis<rbtype, thphbtype> > {
 				
 				// cout << rn << "," << an << "\n";
 				
-				cmat eangc = expm(angcp,20);
+				// cmat eangc = expm(angcp,20);
 				
 				// cout << eangc << "\n";
 				
-				cvec angslect = eangc * angStates;
+				// cvec angslect = eangc * angStates;
+				
+				cvec angslect = expmvec(angcp,angStates,20);
+				
 				// cout << angStates << "\n";
 				// cout << angslect << "\n";
 				vector<int> slids(0);


### PR DESCRIPTION
with a higher performance matrix-vector product implementation, should make startup significantly faster

the expm function was a sort of hacked together way to figure out which angular momentum states would be untouched for the duration of a run with the given interaction Hamiltonian. It got painfully slow at large basis sizes and I was meaning to get around to replacing it with something faster, which I got around to now.